### PR TITLE
Fix XGBoost GPU device param; forward sample/target column to analyze

### DIFF
--- a/modules/ML_models.py
+++ b/modules/ML_models.py
@@ -28,7 +28,7 @@ class SklearnModelWrapper(BaseEstimator):
     def fit(self, X, y):
         """Convert data to GPU tensors before fitting."""
         if isinstance(self.model, (xgb.XGBRegressor, xgb.XGBClassifier)) and self.use_gpu:
-            # ✅ Convert X and y to PyTorch tensors and keep on GPU
+            # Convert X and y to PyTorch tensors and keep on GPU
             X_tensor = torch.as_tensor(X.toarray(), dtype=torch.float32, device="cuda") if hasattr(X, "toarray") else torch.as_tensor(X, dtype=torch.float32, device="cuda")
             y_tensor = torch.as_tensor(y, dtype=torch.float32, device="cuda")
 
@@ -68,41 +68,6 @@ class SklearnModelWrapper(BaseEstimator):
     def score(self, X, y):
         """Use appropriate scoring metric depending on model type."""
         return self.model.score(X, y)
-
-
-
-# class SklearnModelWrapper(BaseEstimator):
-#     def __init__(self, model, is_regressor=False):
-#         self.model = model
-#         self.feature_importances_ = None
-#         self.is_regressor = is_regressor
-
-#     def fit(self, X, y):
-#         self.model.fit(X, y)
-#         if hasattr(self.model, "coef_"):
-#             self.feature_importances_ = self.model.coef_.flatten()
-#         elif hasattr(self.model, "feature_importances_"):
-#             self.feature_importances_ = self.model.feature_importances_
-#         else:
-#             self.feature_importances_ = None
-
-#     def predict(self, X):
-#         """Predict outputs, handling both classification and regression."""
-#         y_pred = self.model.predict(X)
-#         return y_pred if self.is_regressor else y_pred.astype(int)
-
-#     def predict_proba(self, X):
-#         """Predict probabilities for classifiers; return predictions for regressors."""
-#         if self.is_regressor:
-#             return self.predict(X)  # Regression models don't have probability outputs
-#         if hasattr(self.model, "predict_proba"):
-#             return self.model.predict_proba(X)[:, 1]
-#         else:
-#             raise NotImplementedError("This model does not support probability predictions.")
-
-#     def score(self, X, y):
-#         """Use appropriate scoring metric depending on model type."""
-#         return self.model.score(X, y)
 
 
 class PytorchModelWrapper(BaseEstimator):
@@ -211,16 +176,11 @@ def get_model(model_name, args, is_regressor=False):
         "LogisticRegression": SklearnModelWrapper(LogisticRegression(max_iter=1000), is_regressor=is_regressor),
         "RandomForest": SklearnModelWrapper(RandomForestRegressor(max_depth=max_depth, random_state=42), is_regressor=is_regressor) if is_regressor else 
                         SklearnModelWrapper(RandomForestClassifier(max_depth=max_depth, random_state=42), is_regressor=is_regressor),
-        # "XGBoost": SklearnModelWrapper(
-        #     XGBRegressor(max_depth=max_depth, random_state=42, tree_method=tree_method, device=device), use_gpu=use_gpu
-        # ) if is_regressor else SklearnModelWrapper(
-        #     XGBClassifier(max_depth=max_depth, random_state=42, tree_method=tree_method, device=device), use_gpu=use_gpu
-        # ),
         "XGBoost": SklearnModelWrapper(
-            XGBRegressor(max_depth=max_depth, random_state=42, tree_method="gpu_hist" if use_gpu else "hist"), 
+            XGBRegressor(max_depth=max_depth, random_state=42, tree_method=tree_method, device=device), 
             use_gpu=use_gpu, is_regressor=is_regressor
         ) if is_regressor else SklearnModelWrapper(
-            XGBClassifier(max_depth=max_depth, random_state=42, tree_method="gpu_hist" if use_gpu else "hist"), 
+            XGBClassifier(max_depth=max_depth, random_state=42, tree_method=tree_method, device=device), 
             use_gpu=use_gpu, is_regressor=is_regressor
         ),
         "LightGBM": SklearnModelWrapper(
@@ -245,4 +205,3 @@ def get_model(model_name, args, is_regressor=False):
         )
     
     return model_mapping.get(base_name, None)
-

--- a/modules/Precise.py
+++ b/modules/Precise.py
@@ -55,7 +55,7 @@ class Precise:
         self.args.input_dim = self.adata.shape[1]  # Set input dimension
         self.model = get_model(self.model_name, self.args)
         model = copy.deepcopy(self.model)
-        self.shap_visualizer = SHAPVisualizer(self.adata, model.model if isinstance(model, SklearnModelWrapper) else model, self.model_name, self.args, output_dir=self.output_dir)
+        self.shap_visualizer = SHAPVisualizer(self.adata, model.model if isinstance(model, SklearnModelWrapper) else model, self.model_name, self.args, output_dir=self.output_dir, target_column=self.target_column, sample_column=self.sample_column)
         self.prediction_analyzer = PredictionAnalyzer(
             self.adata,
             model=model,
@@ -66,8 +66,8 @@ class Precise:
             results_folder=self.output_dir,
             verbose=self.args.verbose
         )
-        self.boruta_analyzer = BorutaAnalyzer(self.adata, model, model_name, self.celltype, output_dir=self.output_dir, verbose=self.args.verbose)
-        self.rl_analyzer = ReinforcementLearningAnalyzer(self.adata, model, model_name, output_dir=self.output_dir, verbose=self.args.verbose)
+        self.boruta_analyzer = BorutaAnalyzer(self.adata, model, model_name, self.celltype, output_dir=self.output_dir, response_col=self.target_column, sample_col=self.sample_column, verbose=self.args.verbose)
+        self.rl_analyzer = ReinforcementLearningAnalyzer(self.adata, model, model_name, output_dir=self.output_dir, target_column=self.target_column, sample_column=self.sample_column, celltype=self.celltype, verbose=self.args.verbose)
     
     def cv_prediction(self, k_folds=None, seed = 42, verbose = None):
         """
@@ -114,7 +114,7 @@ class Precise:
             chosen_features (list): Features to include in RL analysis.
         """
         model = get_model(self.args.model_name, self.args, is_regressor=True)
-        self.rl_analyzer = ReinforcementLearningAnalyzer(self.adata, model, self.args.model_name.replace('Classifier', ''), output_dir=self.output_dir, verbose=verbose)
+        self.rl_analyzer = ReinforcementLearningAnalyzer(self.adata, model, self.args.model_name.replace('Classifier', ''), output_dir=self.output_dir, target_column=self.target_column, sample_column=self.sample_column, celltype=self.celltype, verbose=verbose)
         return self.rl_analyzer.run_reinforcement_learning(n_iters=n_iters, learning_rate=learning_rate, chosen_features=chosen_features)
     
     def get_rl_distribution(self, iter = None):
@@ -129,7 +129,7 @@ class Precise:
         """
         if not model:
             model = get_model(self.model_name, self.args, is_regressor=True)
-        self.shap_visualizer = SHAPVisualizer(self.adata, model.model if isinstance(model, SklearnModelWrapper) else model, self.model_name, self.args, output_dir=self.output_dir)
+        self.shap_visualizer = SHAPVisualizer(self.adata, model.model if isinstance(model, SklearnModelWrapper) else model, self.model_name, self.args, output_dir=self.output_dir, target_column=self.target_column, sample_column=self.sample_column)
         self.shap_visualizer.shapely_score_barplot(top_k=top_k, save_path = os.path.join(save_path, 'shap_barplot.png') if save_path else None)
         self.shap_visualizer.shap_summary_plot(max_display=top_k, save_path=os.path.join(save_path, 'summary_plot.png') if save_path else None)
 
@@ -152,7 +152,7 @@ class Precise:
         sc.pp.highly_variable_genes(self.adata, n_top_genes=n_top_genes, inplace=True)
         self.adata = self.adata[:, self.adata.var['highly_variable']]
         model = copy.deepcopy(self.model)
-        self.shap_visualizer = SHAPVisualizer(self.adata, model.model if isinstance(model, SklearnModelWrapper) else model, self.model_name, self.args, output_dir=self.output_dir)
+        self.shap_visualizer = SHAPVisualizer(self.adata, model.model if isinstance(model, SklearnModelWrapper) else model, self.model_name, self.args, output_dir=self.output_dir, target_column=self.target_column, sample_column=self.sample_column)
         self.prediction_analyzer = PredictionAnalyzer(
             self.adata,
             model=model,
@@ -163,7 +163,7 @@ class Precise:
             results_folder=self.output_dir,
             verbose=self.args.verbose
         )
-        self.boruta_analyzer = BorutaAnalyzer(self.adata, model, self.model_name, self.celltype, output_dir=self.output_dir, verbose=self.args.verbose)
+        self.boruta_analyzer = BorutaAnalyzer(self.adata, model, self.model_name, self.celltype, output_dir=self.output_dir, response_col=self.target_column, sample_col=self.sample_column, verbose=self.args.verbose)
 
 
     def prune_decision_tree(self, max_depth=4, min_samples_leaf=20, random_state=42, save_path = None):


### PR DESCRIPTION
1) get_model() in ML_models.py used the deprecated tree_method="gpu_hist", which XGBoost ≥2.0 rejects. Switched to tree_method="hist", device="cuda" (the new equivalent), using variables already computed earlier in the function.

2) Precise.py builds SHAPVisualizer, BorutaAnalyzer, and ReinforcementLearningAnalyzer in six places without forwarding target_column/sample_column/celltype. Since those helper classes default to "response"/"sample", any custom column names passed into Precise() were silently dropped, causing validate_anndata to raise immediately on construction (or later, on run_boruta/run_reinforcement_learning) for anyone using non-default column names.