### PR TITLE
Fix SHAP multiclass output, cv_prediction default, and model mapping

### DIFF
--- a/modules/ML_models.py
+++ b/modules/ML_models.py
@@ -14,9 +14,7 @@ from lightgbm import LGBMClassifier, LGBMRegressor
 # from scipy.sparse import csr_matrix  # Ensure correct type checking
 # from cupyx.scipy.sparse import csr_matrix as csr_gpu
 
-import torch
 import xgboost as xgb
-from sklearn.base import BaseEstimator
 
 class SklearnModelWrapper(BaseEstimator):
     def __init__(self, model, is_regressor=False, use_gpu = False):
@@ -189,7 +187,7 @@ def get_model(model_name, args, is_regressor=False):
             LGBMClassifier(max_depth=max_depth, random_state=42, verbose=-1), is_regressor=is_regressor
         ),
         "LinearRegression": SklearnModelWrapper(LinearRegression(), is_regressor=is_regressor),
-        "DecisionTreeClassifier": SklearnModelWrapper(DecisionTreeClassifier(max_depth=max_depth, random_state=42), is_regressor=is_regressor),
+        "DecisionTree": SklearnModelWrapper(DecisionTreeClassifier(max_depth=max_depth, random_state=42), is_regressor=is_regressor),
     }
 
     if base_name.startswith("NeuralNet_"):

--- a/modules/prediction_analysis.py
+++ b/modules/prediction_analysis.py
@@ -123,7 +123,7 @@ class PredictionAnalyzer:
         k_folds=None,
         seed=None,
         weighted_prediction=False,
-        sample_column='sample_name',
+        sample_column='sample',
         response_column='response',
         celltype=None,
         save_adata_with_predictions=False,
@@ -142,7 +142,7 @@ class PredictionAnalyzer:
         weighted_prediction : bool, optional
             If True, sample contributions are weighted by probabilities.
         sample_column : str, optional
-            Column in `adata.obs` containing sample identifiers (default: 'sample_name').
+            Column in `adata.obs` containing sample identifiers (default: 'sample').
         response_column : str, optional
             Column in `adata.obs` containing the binary response variable (default: 'response').
         celltype : str or None, optional

--- a/modules/shap_analysis.py
+++ b/modules/shap_analysis.py
@@ -43,8 +43,14 @@ class SHAPVisualizer:
         if self.model_name in ['XGBoostClassifier', 'LightGBMClassifier', 'RandomForestClassifier', 'DecisionTreeClassifier']:
             self.explainer = shap.TreeExplainer(model)
             self.shap_values = self.explainer.shap_values(self.df)
-            if self.model_name == 'LightGBMClassifier':
+            # Normalize multi-class SHAP output to a 2D (cells x genes) array for the
+            # positive class. Depending on the model / SHAP version this comes back as
+            # a list (one array per class) or a 3D array (cells x genes x classes),
+            # while binary XGBoost returns a 2D array that is left untouched.
+            if isinstance(self.shap_values, list):
                 self.shap_values = self.shap_values[1]
+            elif isinstance(self.shap_values, np.ndarray) and self.shap_values.ndim == 3:
+                self.shap_values = self.shap_values[:, :, 1]
         
         elif 'Neural' in self.model_name:
             tensor_df = torch.tensor(self.df.values, dtype=torch.float32, device=device)


### PR DESCRIPTION
- shap_analysis: normalize list/3D TreeExplainer output to positive-class 2D
- prediction_analysis: cv_prediction default sample_column 'sample_name' -> 'sample'
- ML_models: drop duplicate torch import; fix DecisionTree model_mapping key